### PR TITLE
Added method to return all EntityManager names

### DIFF
--- a/library/Bisna/Doctrine/Container.php
+++ b/library/Bisna/Doctrine/Container.php
@@ -356,13 +356,17 @@ class Container
     }
 
     /**
-     * Retrieves a list of names for all Entity Managers configured
+     * Retrieves a list of names for all Entity Managers configured 
+     * and/or loaded
      * 
      * @return array
      */
     public function getEntityManagerNames()
     {
-       return array_keys($this->configuration['orm']); 
+       $configuredEMs = array_keys($this->configuration['orm']);
+       $loadedEMs = array_keys($this->entityManagers);
+        
+       return array_merge($configuredEMs, $loadedEMs);
     }
     
     /**


### PR DESCRIPTION
This method allows you to retrieve a list of names of all the registered EntityManagers configured in the config file.
