### PR TITLE
Fixed trying to instantiate '' (empty) class

### DIFF
--- a/library/Bisna/Doctrine/Container.php
+++ b/library/Bisna/Doctrine/Container.php
@@ -427,7 +427,9 @@ class Container
 
         // Event Subscribers configuration
         foreach ($config['eventSubscribers'] as $subscriber) {
-            $eventManager->addEventSubscriber(new $subscriber());
+       	    if ($subscriber) {
+       	        $eventManager->addEventSubscriber(new $subscriber());	
+       	    }
         }
 
         return $eventManager;


### PR DESCRIPTION
Fixed trying to instantiate '' class when resources.doctrine.dbal.connections.default.eventSubscribers[] is overridden/specified as an empty array.
