### PR TITLE
Make includePath parameter for new class loaders optional

### DIFF
--- a/library/Bisna/Doctrine/Container.php
+++ b/library/Bisna/Doctrine/Container.php
@@ -108,6 +108,10 @@ class Container
         require_once $classLoaderFile;
         
         foreach ($config['loaders'] as $loaderItem) {
+            if (! isset($loaderItem['includePath'])) {
+                $loaderItem['includePath'] = null;
+            }
+
             $classLoader = new $classLoaderClass($loaderItem['namespace'], $loaderItem['includePath']);
             $classLoader->register();
         }


### PR DESCRIPTION
Added a condition to registerClassLoaders method to make includePath parameter for new class loaders optional.
Doctrine already supported this, but the container did not.
See http://docs.doctrine-project.org/projects/doctrine-common/en/latest/reference/class-loading.html#usage for more information.
