### PR TITLE
Added support for Memcached and Redis cache, and type mappings registering

### DIFF
--- a/library/Bisna/Doctrine/Container.php
+++ b/library/Bisna/Doctrine/Container.php
@@ -552,7 +552,7 @@ class Container
             $adapter->setMemcached($memcache);
         } else if ($adapter instanceof \Doctrine\Common\Cache\RedisCache) {
             // Prevent stupid PHP error of missing extension (if other driver is being used)
-            $redisClassName = '\\Redis';
+            $redisClassName = 'Redis';
             $redis = new $redisClassName();
 
             // Default server configuration


### PR DESCRIPTION
There was a code piece that created and configured Memcache instance if cache adapter was a \Doctrine\Common\Cache\MemcacheCache. I added similar pieces for Memcached and Redis

I also need to register some type mappings and think it's a good idea to do it in Container as well.
