### PR TITLE
Allow overriding of existing mapping types

### DIFF
--- a/library/Bisna/Doctrine/Container.php
+++ b/library/Bisna/Doctrine/Container.php
@@ -553,10 +553,12 @@ class Container
         //DBAL Types configuration
         $types = $config['types'];
 
-        if (Type::hasType($name)) {
-            Type::overrideType($name, $className);
-        } else {
-            Type::addType($name, $className);
+        foreach ($types as $name => $className) {
+            if (Type::hasType($name)) {
+                Type::overrideType($name, $className);
+            } else {
+                Type::addType($name, $className);
+            }
         }
 
         return $configuration;


### PR DESCRIPTION
The configuration option `resources.doctrine.dbal.connections.default.types[]` can only be used to add new mapping types to Doctrine. But I also need support for overriding existing mapping types.

This PR simply checks if a mapping type already exists with `Type::hasType()`. If so, overrides it with `Type::overrideType()`. If not, adds it with `Type::addType()`.
