### PR TITLE
Zf1 d2 include path fixes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,7 +40,7 @@ Here is an example of configuration:
 
     ; Doctrine Common ClassLoader class and file
     resources.doctrine.classLoader.loaderClass = "Doctrine\Common\ClassLoader"
-    resources.doctrine.classLoader.loaderFile  = APPLICATION_PATH "/../library/vendor/doctrine/common/lib/vendor/doctrine/common/lib/Doctrine/Common/ClassLoader.php"
+    resources.doctrine.classLoader.loaderFile  = APPLICATION_PATH "/../library/vendor/doctrine/common/lib/Doctrine/Common/ClassLoader.php"
 
     ; Namespace loader for Doctrine\Common
     resources.doctrine.classLoader.loaders.doctrine_common.namespace   = "Doctrine\Common"

--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -36,7 +36,7 @@ resources.frontController.params.displayExceptions = 0
 ; ------------------------------------------------------------------------------
 
 resources.doctrine.classLoader.loaderClass = "Doctrine\Common\ClassLoader"
-resources.doctrine.classLoader.loaderFile  = APPLICATION_PATH "/../library/vendor/doctrine/common/lib/vendor/doctrine/common/lib/Doctrine/Common/ClassLoader.php"
+resources.doctrine.classLoader.loaderFile  = APPLICATION_PATH "/../library/vendor/doctrine/common/lib/Doctrine/Common/ClassLoader.php"
 
 resources.doctrine.classLoader.loaders.doctrine_common.namespace   = "Doctrine\Common"
 resources.doctrine.classLoader.loaders.doctrine_common.includePath = APPLICATION_PATH "/../library/vendor/doctrine/common/lib/Doctrine/Common"


### PR DESCRIPTION
Hello Guilherme! I noticed that these include paths in the documentation and application.ini are not the same per the directory structure we receive from installing this project via Composer using the composer.json file in the README.md. It looks like they are using a new structure, and I have adjusted the include paths in both files to follow suit.

I have adjusted all but the Yaml component, as I didn't receive that due to my project's configuration.
