### PR TITLE
Allow includePath for annotation namespace to be optional

### DIFF
--- a/library/Bisna/Doctrine/Container.php
+++ b/library/Bisna/Doctrine/Container.php
@@ -1027,7 +1027,7 @@ class Container
             foreach($config['annotationNamespaces'] as $annotationNamespace) {
                 AnnotationRegistry::registerAutoloadNamespace(
                         $annotationNamespace['namespace']
-                        , isset($annotationNamespace['includePath']) ? isset($annotationNamespace['includePath']) : null
+                        , isset($annotationNamespace['includePath']) ? $annotationNamespace['includePath'] : null
                 );
             }
 


### PR DESCRIPTION
The second parameter of AnnotationRegistry::registerAutoloadNamespace() is optional. Respect this by not enforcing it in application.ini. 

This entry is still mandatory:
`resources.doctrine.orm.entityManagers.default.metadataDrivers.annotationRegistry.annotationNamespaces.0.namespace`

This entry is now optional:
`resources.doctrine.orm.entityManagers.default.metadataDrivers.annotationRegistry.annotationNamespaces.0.includePath`

https://github.com/doctrine/annotations/blob/master/lib/Doctrine/Common/Annotations/AnnotationRegistry.php#L70
