### PR TITLE
Fix $configuration->setAutoGenerateProxyClasses() when option is boolean TRUE

### DIFF
--- a/library/Bisna/Doctrine/Container.php
+++ b/library/Bisna/Doctrine/Container.php
@@ -775,6 +775,7 @@ class Container
 
         // Proxy configuration
         $configuration->setAutoGenerateProxyClasses(
+            $config['proxy']['autoGenerateClasses'] === true ||
             ! in_array($config['proxy']['autoGenerateClasses'], array("0", "false", false))
         );
         $configuration->setProxyNamespace($config['proxy']['namespace']);
@@ -821,6 +822,7 @@ class Container
 
         // Proxy configuration
         $configuration->setAutoGenerateProxyClasses(
+            $config['proxy']['autoGenerateClasses'] === true ||
             ! in_array($config['proxy']['autoGenerateClasses'], array("0", "false", false))
         );
         $configuration->setProxyNamespace($config['proxy']['namespace']);


### PR DESCRIPTION
I've just switched to using Yaml for configuration files (using symfony/yaml 2.3):

In `startORMConfiguration()` (and `startODMConfiguration`) the value of `$config['proxy']['autoGenerateClasses']` will be an actual boolean. When that boolean is TRUE, this check:

```
in_array($config['proxy']['autoGenerateClasses'], array("0", "false", false))
```

Will return TRUE (because of type-casting inside `in_array()`).
Therefor the call to `$configuration->setAutoGenerateProxyClasses()` will actually disable autogeneration when `$config['proxy']['autoGenerateClasses']` is TRUE.

This PR fixes that :)
