### PR TITLE
Allow installation of doctrine/orm 2.4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "guilhermeblanco/zendframework1-doctrine2",
     "require": {
         "zendframework/zendframework1": "~1.9",
-        "doctrine/orm": ">=2.3.*"
+        "doctrine/orm": "~2.3"
     },
     "autoload": {
         "psr-0": {"Bisna": "library/"}


### PR DESCRIPTION
When trying to upgrade to doctrine/orm 2.4.x, composer complains. Just tested it with this patch, seems to work at first sight.

Composer output:

 Problem 1
    - Conclusion: don't install doctrine/orm v2.4.0
    - Conclusion: don't install doctrine/orm 2.4.0-RC2
    - Conclusion: don't install doctrine/orm 2.4.0-RC1
    - Conclusion: don't install doctrine/orm 2.4.0-BETA2
    - guilhermeblanco/zendframework1-doctrine2 dev-master requires doctrine/orm 2.3.x -> satisfiable by doctrine/orm[2.3.4, 2.3.0, 2.3.0-BETA1, 2.3.0-RC1, 2.3.0-RC2, 2.3.0-RC3, 2.3.0-RC4, 2.3.1, 2.3.2, 2.3.3].
