### PR TITLE
Added FilesystemCache support

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -72,6 +72,12 @@ resources.doctrine.cache.instances.default.options.servers.0.port = 11211
 ;resources.doctrine.cache.instances.default.options.servers.0.retryInterval = 15
 ;resources.doctrine.cache.instances.default.options.servers.0.status        = true
 
+; Cache Instance configuration example for "default" FilesystemCache
+;resources.doctrine.cache.instances.default.adapterClass = "Doctrine\Common\Cache\FilesystemCache"
+;resources.doctrine.cache.instances.default.namespace    = "Application_"
+;resources.doctrine.cache.instances.default.options.directory    = "/tmp/doctrine"
+;resources.doctrine.cache.instances.default.options.extension    = ".doctrinecache.data"
+
 ; ------------------------------------------------------------------------------
 ; Doctrine DBAL Configuration
 ; ------------------------------------------------------------------------------

--- a/library/Bisna/Doctrine/Container.php
+++ b/library/Bisna/Doctrine/Container.php
@@ -602,8 +602,16 @@ class Container
     private function startCacheInstance(array $config = array())
     {
         $adapterClass = $config['adapterClass'];
-        $adapter = new $adapterClass();
-
+        
+        // FilesystemCache (extending abstract FileCache class) expects the directory as a parameter in the constructor
+        if( $adapterClass == 'Doctrine\Common\Cache\FilesystemCache') {
+            $directory = isset($config['options']['directory']) ? $config['options']['directory'] : '/tmp/doctrine';
+            $extension = isset($config['options']['extension']) ? $config['options']['extension'] : null;
+            $adapter = new $adapterClass($directory, $extension);
+        } else {
+            $adapter = new $adapterClass();
+        }
+        
         // Define namespace for cache
         if (isset($config['namespace']) && ! empty($config['namespace'])) {
             $adapter->setNamespace($config['namespace']);


### PR DESCRIPTION
Added FilesystemCache support to Container::startCacheInstance() as it expects the directory as a parameter in the constructor.