### PR TITLE
Allow third party FilesystemCache or FileCache class

### DIFF
--- a/library/Bisna/Doctrine/Container.php
+++ b/library/Bisna/Doctrine/Container.php
@@ -604,7 +604,7 @@ class Container
         $adapterClass = $config['adapterClass'];
         
         // FilesystemCache (extending abstract FileCache class) expects the directory as a parameter in the constructor
-        if( $adapterClass == 'Doctrine\Common\Cache\FilesystemCache') {
+        if( strrpos($adapterClass, 'FilesystemCache') !== FALSE || strrpos($adapterClass, 'FileCache') !== FALSE ) {
             $directory = isset($config['options']['directory']) ? $config['options']['directory'] : '/tmp/doctrine';
             $extension = isset($config['options']['extension']) ? $config['options']['extension'] : null;
             $adapter = new $adapterClass($directory, $extension);


### PR DESCRIPTION
Modified `Bisna\Doctrine\Container::startCacheInstance()` as it was relying on class name checking to pass in configuration parameters. I modified it to only check for the class name, ignoring the namespace.
This now allows all adapters named `FilesystemCache` and `FileCache` to have the directory and extension passed into the constructor.
